### PR TITLE
Add numerology, horoscope, and supportive chat sections with free and paid reports

### DIFF
--- a/app/Models/HoroscopeReading.php
+++ b/app/Models/HoroscopeReading.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class HoroscopeReading extends Model
+{
+    protected $fillable = [
+        'chat_id', 'user_name', 'surname', 'birth_date', 'birth_time', 'sign', 'type', 'result', 'meta'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'birth_date' => 'date',
+        'birth_time' => 'datetime:H:i',
+    ];
+}

--- a/app/Models/NumerologyReading.php
+++ b/app/Models/NumerologyReading.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NumerologyReading extends Model
+{
+    protected $fillable = [
+        'chat_id', 'user_name', 'surname', 'birth_date', 'type', 'result', 'meta'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'birth_date' => 'date',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,5 +17,5 @@ class User extends Authenticatable
      *
      * @var list<string>
      */
-    protected $fillable = ['chat_id', 'name', 'birth_date', 'subscription', 'subscription_expires_at'];
+    protected $fillable = ['chat_id', 'name', 'surname', 'birth_date', 'birth_time', 'subscription', 'subscription_expires_at'];
 }

--- a/database/migrations/2025_09_03_232804_add_surname_to_users_table.php
+++ b/database/migrations/2025_09_03_232804_add_surname_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('surname')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('surname');
+        });
+    }
+};

--- a/database/migrations/2025_09_03_232805_create_numerology_readings_table.php
+++ b/database/migrations/2025_09_03_232805_create_numerology_readings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('numerology_readings', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('chat_id')->index();
+            $table->string('user_name')->nullable();
+            $table->string('surname')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('type')->default('free');
+            $table->text('result')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('numerology_readings');
+    }
+};

--- a/database/migrations/2025_09_03_232806_add_birth_time_to_users_table.php
+++ b/database/migrations/2025_09_03_232806_add_birth_time_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->time('birth_time')->nullable()->after('birth_date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('birth_time');
+        });
+    }
+};

--- a/database/migrations/2025_09_03_232807_create_horoscope_readings_table.php
+++ b/database/migrations/2025_09_03_232807_create_horoscope_readings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('horoscope_readings', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('chat_id')->index();
+            $table->string('user_name')->nullable();
+            $table->string('surname')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->time('birth_time')->nullable();
+            $table->string('sign')->nullable();
+            $table->string('type')->default('daily');
+            $table->text('result')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('horoscope_readings');
+    }
+};


### PR DESCRIPTION
## Summary
- add horoscope flow prompting for surname and birth time
- implement free daily and subscription-gated full horoscopes via AI
- persist horoscope readings and user birth time
- fix newline escaping so free numerology and horoscope messages render on separate lines
- add supportive "Podruzhka" chat with free one-off advice, paid ongoing conversations, and distress message handling
- extend AI service with generic chat method

## Testing
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e0eaed08832691f7dcf62b800736