### PR TITLE
Add numerology, horoscope, and supportive chat sections with free and paid reports

### DIFF
--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Attributes\AsCommand;
+use App\Models\Reminder;
+use App\Services\TgService;
+
+#[AsCommand(name: 'send:reminders', description: 'Send scheduled reminder messages')]
+class SendReminders extends Command
+{
+    protected $signature = 'send:reminders';
+    protected $description = 'Send scheduled reminder messages';
+
+    public function __construct(protected TgService $tg)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): void
+    {
+        Reminder::whereNull('sent_at')
+            ->where('send_at', '<=', now())
+            ->chunkById(100, function ($reminders) {
+                foreach ($reminders as $reminder) {
+                    $this->tg->sendMessage($reminder->chat_id, $reminder->message);
+                    $reminder->sent_at = now();
+                    $reminder->save();
+                }
+            });
+    }
+}

--- a/app/Models/HoroscopeReading.php
+++ b/app/Models/HoroscopeReading.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class HoroscopeReading extends Model
+{
+    protected $fillable = [
+        'chat_id', 'user_name', 'surname', 'birth_date', 'birth_time', 'sign', 'type', 'result', 'meta'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'birth_date' => 'date',
+        'birth_time' => 'datetime:H:i',
+    ];
+}

--- a/app/Models/NumerologyReading.php
+++ b/app/Models/NumerologyReading.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NumerologyReading extends Model
+{
+    protected $fillable = [
+        'chat_id', 'user_name', 'surname', 'birth_date', 'type', 'result', 'meta'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'birth_date' => 'date',
+    ];
+}

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reminder extends Model
+{
+    protected $fillable = ['chat_id', 'message', 'send_at', 'sent_at'];
+
+    protected $casts = [
+        'send_at' => 'datetime',
+        'sent_at' => 'datetime',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,5 +17,12 @@ class User extends Authenticatable
      *
      * @var list<string>
      */
-    protected $fillable = ['chat_id', 'name', 'birth_date', 'subscription', 'subscription_expires_at'];
+    protected $fillable = ['chat_id', 'name', 'surname', 'birth_date', 'birth_time', 'subscription', 'subscription_expires_at', 'podruzhka_free_used_at'];
+
+    protected $casts = [
+        'birth_date' => 'date',
+        'birth_time' => 'datetime:H:i',
+        'subscription_expires_at' => 'datetime',
+        'podruzhka_free_used_at' => 'datetime',
+    ];
 }

--- a/app/Services/AIService.php
+++ b/app/Services/AIService.php
@@ -25,21 +25,59 @@ class AIService
      */
     public function getAnswer(string $message, ?string $systemMessage = null): string
     {
-        try {
-            $messages = [];
+        $messages = [];
 
-            if ($systemMessage) {
-                $messages[] = [
-                    'role' => 'system',
-                    'content' => $systemMessage
-                ];
+        if ($systemMessage) {
+            $messages[] = [
+                'role' => 'system',
+                'content' => $systemMessage
+            ];
+        }
+
+        $messages[] = [
+            'role' => 'user',
+            'content' => $message
+        ];
+
+        try {
+            $response = Http::withHeaders([
+                'Authorization' => "Bearer {$this->apiKey}",
+                'Content-Type'  => 'application/json',
+            ])->timeout(30)
+                ->post('https://api.openai.com/v1/chat/completions', [
+                    'model' => $this->model,
+                    'messages' => $messages,
+                    'temperature' => $this->temperature,
+                    'max_tokens' => $this->maxTokens,
+                ]);
+
+            if ($response->failed()) {
+                Log::warning('OpenAI API failed', ['status' => $response->status(), 'body' => $response->body()]);
+                throw new \RuntimeException('OpenAI API request failed');
             }
 
-            $messages[] = [
-                'role' => 'user',
-                'content' => $message
-            ];
+            $data = $response->json();
+        } catch (\Throwable $e) {
+            Log::warning('OpenAI API error: '.$e->getMessage());
+            throw $e;
+        }
 
+        Log::info('OpenAI response: '.json_encode($data));
+
+        if (isset($data['choices'][0]['message']['content'])) {
+            return trim($data['choices'][0]['message']['content']);
+        }
+
+        throw new \RuntimeException('Empty response from OpenAI');
+    }
+
+    /**
+     * Универсальный метод для ведения диалога с сохранением контекста
+     * @param array<int, array{role:string,content:string}> $messages
+     */
+    public function chat(array $messages): string
+    {
+        try {
             $response = Http::withHeaders([
                 'Authorization' => "Bearer {$this->apiKey}",
                 'Content-Type'  => 'application/json',
@@ -53,17 +91,16 @@ class AIService
 
             $data = $response->json();
 
-            \Log::info('OpenAI response: '.json_encode($data));
+            Log::info('OpenAI response: '.json_encode($data));
 
             if (isset($data['choices'][0]['message']['content'])) {
                 return trim($data['choices'][0]['message']['content']);
             }
 
-            // дружелюбное сообщение пользователю
-            return "К сожалению, сейчас я не могу подготовить расклад. Но не переживай — мы обязательно вернёмся к этому чуть позже и я помогу тебе с ответами.";
+            return 'Сейчас мне сложно поддержать диалог, попробуй чуть позже.';
         } catch (\Exception $e) {
             Log::warning("OpenAI API error: ".$e->getMessage());
-            return "К сожалению, сейчас я не могу подготовить расклад. Но не переживай — мы обязательно вернёмся к этому чуть позже и я помогу тебе с ответами.";
+            return 'Сейчас мне сложно поддержать диалог, попробуй чуть позже.';
         }
     }
 }

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -5,8 +5,12 @@ namespace App\Services;
 use App\Models\User;
 use App\Models\TgSession;
 use App\Models\TaroReading;
+use App\Models\NumerologyReading;
+use App\Models\HoroscopeReading;
+use App\Models\Reminder;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
 
 class ChatService
 {
@@ -88,6 +92,81 @@ class ChatService
                 $this->handleTaroQuestion($session, $user, $chatId, $text);
                 break;
 
+            case 'numerology_ask_surname':
+                if (empty($text)) {
+                    $this->tg->sendMessage($chatId, 'Пожалуйста, напиши фамилию.');
+                    break;
+                }
+                $user->surname = mb_substr($text, 0, 100);
+                $user->save();
+
+                $this->renderNumerologyMenu($chatId, $user);
+                $session->state = 'numerology_menu';
+                break;
+
+            case 'numerology_menu':
+                $this->routeNumerologyMenu($session, $user, $chatId, $text);
+                break;
+
+            case 'horoscope_ask_surname':
+                if (empty($text)) {
+                    $this->tg->sendMessage($chatId, 'Пожалуйста, напиши фамилию.');
+                    break;
+                }
+                $user->surname = mb_substr($text, 0, 100);
+                $user->save();
+
+                if (!$user->birth_time) {
+                    $this->tg->sendMessage($chatId,
+                        'Укажи время рождения в формате ЧЧ:ММ. Если не знаешь, нажми «Не знаю».',
+                        [['Не знаю']]
+                    );
+                    $session->state = 'horoscope_ask_birth_time';
+                } else {
+                    $this->showHoroscopeMenu($chatId, $user);
+                    $session->state = 'horoscope_menu';
+                }
+                break;
+
+            case 'horoscope_ask_birth_time':
+                if ($text === 'Не знаю') {
+                    $user->birth_time = null;
+                    $user->save();
+                    $this->showHoroscopeMenu($chatId, $user);
+                    $session->state = 'horoscope_menu';
+                    break;
+                }
+
+                if (!$this->validateTime($text)) {
+                    $this->tg->sendMessage($chatId,
+                        'Пожалуйста, введи время в формате ЧЧ:ММ (например: 08:30) или нажми «Не знаю».',
+                        [['Не знаю']]
+                    );
+                    break;
+                }
+
+                $user->birth_time = $text . ':00';
+                $user->save();
+                $this->showHoroscopeMenu($chatId, $user);
+                $session->state = 'horoscope_menu';
+                break;
+
+            case 'horoscope_menu':
+                $this->routeHoroscopeMenu($session, $user, $chatId, $text);
+                break;
+
+            case 'podruzhka_free':
+                $this->handlePodruzhkaFree($session, $user, $chatId, $text);
+                break;
+
+            case 'podruzhka_chat':
+                $this->handlePodruzhkaChat($session, $user, $chatId, $text);
+                break;
+
+            case 'subscription_menu':
+                $this->routeSubscriptionMenu($session, $user, $chatId, $text);
+                break;
+
             default:
                 // На всякий случай — возвращаем в главное меню
                 $this->showMainMenu($chatId, $user);
@@ -119,7 +198,7 @@ class ChatService
         $keyboard = [
             ['🃏 Расклад Таро', '🔢 Нумерология'],
             ['♒ Гороскоп', '💬 Подружка'],
-            ['Подписка', 'Помощь']
+            ['💎 Подписка', 'ℹ️ Помощь']
         ];
         $this->tg->sendMessage($chatId, $text, $keyboard);
     }
@@ -137,14 +216,55 @@ class ChatService
                 break;
 
             case '🔢 Нумерология':
-            case '♒ Гороскоп':
-            case '💬 Подружка':
-            case 'Подписка':
-                // Для остальных — заглушки (реализованы отдельно)
-                $this->tg->sendMessage($chatId, "Этот раздел пока в разработке. Выбери, пожалуйста, другой раздел или вернись позже.", [['Назад в меню']]);
+                if (!$user->surname) {
+                    $this->tg->sendMessage($chatId, 'Пожалуйста, укажи свою фамилию:');
+                    $session->state = 'numerology_ask_surname';
+                } else {
+                    $this->renderNumerologyMenu($chatId, $user);
+                    $session->state = 'numerology_menu';
+                }
                 break;
 
-            case 'Помощь':
+            case '♒ Гороскоп':
+                if (!$user->surname) {
+                    $this->tg->sendMessage($chatId, 'Пожалуйста, укажи свою фамилию:');
+                    $session->state = 'horoscope_ask_surname';
+                } elseif (!$user->birth_time) {
+                    $this->tg->sendMessage($chatId,
+                        'Укажи время рождения в формате ЧЧ:ММ. Если не знаешь, нажми «Не знаю».',
+                        [['Не знаю']]
+                    );
+                    $session->state = 'horoscope_ask_birth_time';
+                } else {
+                    $this->showHoroscopeMenu($chatId, $user);
+                    $session->state = 'horoscope_menu';
+                }
+                break;
+
+            case '💬 Подружка':
+                if ($user->subscription !== 'paid' && $user->podruzhka_free_used_at) {
+                    $this->tg->sendMessage($chatId,
+                        "Бесплатный совет уже получен. Чтобы продолжить беседу без ограничений, оформи подписку 💗",
+                        [['Получить доступ', 'Назад в меню']]
+                    );
+                    break;
+                }
+
+                $this->tg->sendMessage($chatId,
+                    "Привет, я твоя Подружка. Можешь рассказать мне всё, что у тебя на душе. Я рядом, выслушаю, пойму",
+                    [['Закончить разговор']]
+                );
+
+                $session->state = $user->subscription === 'paid' ? 'podruzhka_chat' : 'podruzhka_free';
+                break;
+
+            case '💎 Подписка':
+            case 'Получить доступ':
+                $this->showSubscriptionMenu($chatId);
+                $session->state = 'subscription_menu';
+                break;
+
+            case 'ℹ️ Помощь':
                 $this->tg->sendMessage($chatId,
                     "Я помогу:\n• Сформулировать вопрос к Таро\n• Сделать базовый расклад (3 карты бесплатно) или глубокий расклад (7 карт для подписчиков)\n\n".
                     "Просто выбери «🃏 Расклад Таро» и следуй подсказкам.");
@@ -197,16 +317,14 @@ class ChatService
 
         // Проверка лимита бесплатных раскладов
         if ($user->subscription !== 'paid') {
-            $freeUsedToday = TaroReading::where('chat_id', $user->chat_id)
-                ->whereDate('created_at', now()->toDateString())
+            $freeCount = TaroReading::where('chat_id', $user->chat_id)
                 ->where('cards_count', 3)
                 ->count();
-
-            if ($freeUsedToday >= 3) {
+            if ($freeCount >= 1) {
                 $this->tg->sendMessage($chatId,
-                    "Ты использовала все 3 бесплатных расклада на сегодня 🌸\n\n" .
-                    "Если хочешь продолжить, можно оформить платную подписку (7 карт и персональные рекомендации).",
-                    [['Подписка', 'Назад в меню']]
+                    "Бесплатный расклад уже был использован. 🌸\n\n" .
+                    "Чтобы делать больше раскладов и получать рекомендации, подключи подписку.",
+                    [['Получить доступ', 'Назад в меню']]
                 );
                 $session->state = 'main_menu';
                 return;
@@ -242,7 +360,7 @@ class ChatService
         // Мягкое сообщение ожидания
         $this->tg->sendMessage($chatId, "Сейчас я посоветуюсь с картами и соберу расклад — это займёт пару секунд ✨");
 
-        $result = $this->ai->getAnswer($prompt);
+        $result = $this->askAi($prompt);
 
         if (!$result) {
             $result = "К сожалению, сейчас я не могу подготовить расклад. Но не переживай — мы вернёмся к этому чуть позже.";
@@ -275,14 +393,321 @@ class ChatService
         ]);
 
         // Отправляем результат и клавиатуру
-        $keyboard = $user->subscription === 'paid'
-            ? [['Задать ещё вопрос', 'Назад в меню']]
-            : [['Подписка', 'Задать ещё вопрос'], ['Назад в меню']];
+        if ($user->subscription === 'paid') {
+            $this->tg->sendMessage($chatId, $final, [['Задать ещё вопрос', 'Назад в меню']]);
+            $session->state = 'taro_menu';
+        } else {
+            $final .= "\n\nСпасибо, что доверилась. Если хочешь получать больше раскладов и персональные рекомендации — подключи подписку 💎";
+            $this->tg->sendMessage($chatId, $final, [['Получить доступ', 'Назад в меню']]);
+            $this->scheduleRetention($user);
+            $session->state = 'main_menu';
+        }
+    }
 
-        $this->tg->sendMessage($chatId, $final, $keyboard);
+    protected function renderNumerologyMenu(int $chatId, User $user)
+    {
+        $text = 'Выбери формат нумерологического разбора:';
+        $keyboard = [
+            ['Бесплатно', 'Полный анализ'],
+            ['Назад в меню']
+        ];
+        $this->tg->sendMessage($chatId, $text, $keyboard);
+    }
 
-        // Сохраняем состояние
-        $session->state = 'taro_menu';
+    protected function showHoroscopeMenu(int $chatId, User $user)
+    {
+        $text = 'Выбери формат гороскопа:';
+        $keyboard = [
+            ['Бесплатно', 'Полный гороскоп'],
+            ['Назад в меню']
+        ];
+        $this->tg->sendMessage($chatId, $text, $keyboard);
+    }
+
+    protected function routeNumerologyMenu($session, User $user, int $chatId, string $text)
+    {
+        switch ($text) {
+            case 'Бесплатно':
+                $this->handleNumerologyFree($session, $user, $chatId);
+                break;
+
+            case 'Полный анализ':
+                $this->handleNumerologyPaid($session, $user, $chatId);
+                break;
+
+            case 'Назад в меню':
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            default:
+                $this->renderNumerologyMenu($chatId, $user);
+                break;
+        }
+    }
+
+    protected function routeHoroscopeMenu($session, User $user, int $chatId, string $text)
+    {
+        switch ($text) {
+            case 'Бесплатно':
+                $this->handleHoroscopeFree($session, $user, $chatId);
+                break;
+
+            case 'Полный гороскоп':
+                $this->handleHoroscopePaid($session, $user, $chatId);
+                break;
+
+            case 'Назад в меню':
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            default:
+                $this->showHoroscopeMenu($chatId, $user);
+                break;
+        }
+    }
+
+    protected function handlePodruzhkaFree($session, User $user, int $chatId, string $text)
+    {
+        if ($text === 'Закончить разговор') {
+            $this->tg->sendMessage($chatId, 'Спасибо, что доверилась мне. Помни: ты ценная и важная. Я всегда рядом, когда захочешь поговорить.');
+            $this->showMainMenu($chatId, $user);
+            $session->state = 'main_menu';
+            return;
+        }
+
+        if ($this->isDistressMessage($text)) {
+            $this->tg->sendMessage($chatId, 'Если тебе очень тяжело, пожалуйста, обратись к специалисту. Я рядом, но живой человек — лучшее решение в таких ситуациях.', [['Закончить разговор']]);
+            return;
+        }
+
+        $reply = $this->askAi($text, $this->buildPodruzhkaSystemPrompt());
+        if (mb_strlen($reply) > 300) {
+            $reply = mb_substr($reply, 0, 300) . '...';
+        }
+
+        $final = $reply . "\n\nСпасибо, что написала. Я рядом, даже когда трудно. 💗\n" .
+            "Если хочешь продолжать беседу без ограничений и получать упражнения и поддержку в любой момент — подключи подписку.";
+
+        $this->tg->sendMessage($chatId, $final, [['Получить доступ', 'Назад в меню']]);
+        $user->podruzhka_free_used_at = now();
+        $user->save();
+        $this->scheduleRetention($user);
+        $session->state = 'main_menu';
+    }
+
+    protected function handlePodruzhkaChat($session, User $user, int $chatId, string $text)
+    {
+        if ($text === 'Закончить разговор') {
+            $this->tg->sendMessage($chatId, 'Спасибо, что доверилась мне. Помни: ты ценная и важная. Я всегда рядом, когда захочешь поговорить.');
+            $this->showMainMenu($chatId, $user);
+            $session->state = 'main_menu';
+            return;
+        }
+
+        if ($this->isDistressMessage($text)) {
+            $this->tg->sendMessage($chatId, 'Если тебе очень тяжело, пожалуйста, обратись к специалисту. Я рядом, но живой человек — лучшее решение в таких ситуациях.', [['Закончить разговор']]);
+            return;
+        }
+
+        $reply = $this->askAi($text, $this->buildPodruzhkaSystemPrompt());
+        if (mb_strlen($reply) > 4000) {
+            $reply = mb_substr($reply, 0, 4000) . '...';
+        }
+
+        $this->tg->sendMessage($chatId, $reply, [['Закончить разговор']]);
+        $session->state = 'podruzhka_chat';
+    }
+
+    protected function handleNumerologyFree($session, User $user, int $chatId)
+    {
+        if ($user->subscription !== 'paid') {
+            $used = NumerologyReading::where('chat_id', $user->chat_id)
+                ->where('type', 'money_code')
+                ->exists();
+            if ($used) {
+                $this->tg->sendMessage($chatId,
+                    'Бесплатный расчёт уже доступен только один раз. Чтобы получить полный разбор, оформи подписку.',
+                    [['Получить доступ', 'Назад в меню']]
+                );
+                $session->state = 'main_menu';
+                return;
+            }
+        }
+
+        $prompt = $this->buildMoneyCodePrompt($user->name ?? '', $user->birth_date);
+        $this->tg->sendMessage($chatId, 'Считаю твой денежный код, подожди пару секунд ✨');
+        $result = $this->askAi($prompt);
+
+        if (!$result) {
+            $result = 'Сейчас не получается рассчитать код. Попробуй ещё раз позже.';
+        }
+
+        if (mb_strlen($result) > 4000) {
+            $result = mb_substr($result, 0, 4000) . '...';
+        }
+
+        $final = $result . "\n\nЭто твой денежный код. Он помогает понять, как ты взаимодействуешь с финансовыми потоками. 💸\n" .
+            "Спасибо, что попробовала! Если хочешь узнать свои сильные стороны, кармические задачи и код активации изобилия, подключи подписку и получи расширенный нумерологический портрет. ✨";
+
+        $this->tg->sendMessage($chatId, $final, [['Получить доступ', 'Назад в меню']]);
+        $this->scheduleRetention($user);
+
+        NumerologyReading::create([
+            'chat_id' => $user->chat_id,
+            'user_name' => $user->name,
+            'surname' => $user->surname,
+            'birth_date' => $user->birth_date,
+            'type' => 'money_code',
+            'result' => $result,
+            'meta' => [
+                'generated_at' => now()->toDateTimeString(),
+                'prompt' => $this->shorten($prompt, 800),
+            ],
+        ]);
+
+        $session->state = 'main_menu';
+    }
+
+    protected function handleNumerologyPaid($session, User $user, int $chatId)
+    {
+        if ($user->subscription !== 'paid') {
+            $this->tg->sendMessage($chatId,
+                'Подробный нумерологический анализ доступен по подписке.',
+                [['Получить доступ', 'Назад в меню']]
+            );
+            $session->state = 'numerology_menu';
+            return;
+        }
+
+        $birth = $user->birth_date ? Carbon::parse($user->birth_date)->format('d.m.Y') : '';
+        $prompt = $this->buildNumerologyPrompt($user->name ?? '', $user->surname ?? '', $birth);
+        $this->tg->sendMessage($chatId, 'Собираю твою нумерологическую карту, подожди чуть-чуть ✨');
+        $result = $this->askAi($prompt);
+
+        if (!$result) {
+            $result = 'Сейчас не получается подготовить анализ. Попробуй позже.';
+        }
+
+        if (mb_strlen($result) > 4000) {
+            $result = mb_substr($result, 0, 4000) . '...';
+        }
+
+        $this->tg->sendMessage($chatId, $result, [['Задать вопрос', 'Назад в меню']]);
+
+        NumerologyReading::create([
+            'chat_id' => $user->chat_id,
+            'user_name' => $user->name,
+            'surname' => $user->surname,
+            'birth_date' => $user->birth_date,
+            'type' => 'full',
+            'result' => $result,
+            'meta' => [
+                'generated_at' => now()->toDateTimeString(),
+                'prompt' => $this->shorten($prompt, 800),
+            ],
+        ]);
+
+        $session->state = 'numerology_menu';
+    }
+
+    protected function handleHoroscopeFree($session, User $user, int $chatId)
+    {
+        if ($user->subscription !== 'paid') {
+            $used = HoroscopeReading::where('chat_id', $user->chat_id)
+                ->where('type', 'daily')
+                ->exists();
+            if ($used) {
+                $this->tg->sendMessage($chatId,
+                    'Ты уже получила краткий гороскоп. Чтобы узнать больше и получить полный прогноз, подключи подписку 🌌',
+                    [['Получить доступ', 'Назад в меню']]
+                );
+                $session->state = 'main_menu';
+                return;
+            }
+        }
+
+        $sign = $this->getZodiacSign($user->birth_date);
+        $prompt = $this->buildHoroscopeFreePrompt($sign);
+        $this->tg->sendMessage($chatId, 'Смотрю твою астрологическую волну, подожди пару секунд ✨');
+        $result = $this->askAi($prompt);
+
+        if (!$result) {
+            $result = 'Сейчас не получается построить гороскоп. Попробуй позже.';
+        }
+
+        if (mb_strlen($result) > 4000) {
+            $result = mb_substr($result, 0, 4000) . '...';
+        }
+
+        $final = "Твой знак — {$sign}.\n" . $result . "\n\nЭто краткий взгляд на твою текущую астрологическую волну.\n" .
+            "Спасибо, что заглянула! Полный гороскоп по всем сферам жизни доступен по подписке: любовь, деньги, самореализация. 🌌";
+
+        $this->tg->sendMessage($chatId, $final, [['Получить доступ', 'Назад в меню']]);
+        $this->scheduleRetention($user);
+
+        HoroscopeReading::create([
+            'chat_id' => $user->chat_id,
+            'user_name' => $user->name,
+            'surname' => $user->surname,
+            'birth_date' => $user->birth_date,
+            'birth_time' => $user->birth_time,
+            'sign' => $sign,
+            'type' => 'daily',
+            'result' => $result,
+            'meta' => [
+                'generated_at' => now()->toDateTimeString(),
+                'prompt' => $this->shorten($prompt, 800),
+            ],
+        ]);
+
+        $session->state = 'main_menu';
+    }
+
+    protected function handleHoroscopePaid($session, User $user, int $chatId)
+    {
+        if ($user->subscription !== 'paid') {
+            $this->tg->sendMessage($chatId,
+                'Полный гороскоп доступен по подписке.',
+                [['Получить доступ', 'Назад в меню']]
+            );
+            $session->state = 'horoscope_menu';
+            return;
+        }
+
+        $birth = $user->birth_date ? Carbon::parse($user->birth_date)->format('d.m.Y') : '';
+        $time = $user->birth_time ? Carbon::parse($user->birth_time)->format('H:i') : 'неизвестно';
+        $prompt = $this->buildHoroscopePrompt($user->name ?? '', $user->surname ?? '', $birth, $time);
+        $this->tg->sendMessage($chatId, 'Готовлю твой подробный гороскоп, подожди немного ✨');
+        $result = $this->askAi($prompt);
+
+        if (!$result) {
+            $result = 'Сейчас не получается подготовить гороскоп. Попробуй позже.';
+        }
+
+        if (mb_strlen($result) > 4000) {
+            $result = mb_substr($result, 0, 4000) . '...';
+        }
+
+        $this->tg->sendMessage($chatId, $result, [['Назад в меню']]);
+
+        HoroscopeReading::create([
+            'chat_id' => $user->chat_id,
+            'user_name' => $user->name,
+            'surname' => $user->surname,
+            'birth_date' => $user->birth_date,
+            'birth_time' => $user->birth_time,
+            'sign' => $this->getZodiacSign($user->birth_date),
+            'type' => 'full',
+            'result' => $result,
+            'meta' => [
+                'generated_at' => now()->toDateTimeString(),
+                'prompt' => $this->shorten($prompt, 800),
+            ],
+        ]);
+
+        $session->state = 'horoscope_menu';
     }
 
     /* ---------- Вспомогательные утилиты ---------- */
@@ -304,6 +729,83 @@ class ChatService
         }
     }
 
+    protected function validateTime(string $text): bool
+    {
+        if (!preg_match('/^\d{2}:\d{2}$/', $text)) return false;
+        [$h, $m] = explode(':', $text);
+        return $h >= 0 && $h < 24 && $m >= 0 && $m < 60;
+    }
+
+    protected function buildPodruzhkaSystemPrompt(): string
+    {
+        return 'Ты — добрая, понимающая, внимательная подруга. Твоя задача — поддерживать, выслушивать, помогать словами и мягко направлять, если нужно. Никакой оценки. Ты можешь говорить с юмором, тепло, но всегда с уважением. Избегай клише и сухих фраз.';
+    }
+
+    protected function isDistressMessage(string $text): bool
+    {
+        $t = mb_strtolower($text);
+        foreach (["суиц", "самоуб", "убью", "смерть", "умереть"] as $word) {
+            if (str_contains($t, $word)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function buildMoneyCodePrompt(string $name, ?string $birthDate): string
+    {
+        $birth = $birthDate ? Carbon::parse($birthDate)->format('d.m.Y') : '';
+        return "На основе имени {$name} и даты рождения {$birth} вычисли денежный (финансовый) код. " .
+            "Верни одну цифру и краткое пояснение (1-2 предложения). Отвечай по-русски.";
+    }
+
+    protected function buildNumerologyPrompt(string $name, string $surname, string $birthDate): string
+    {
+        $system = "Ты — дружелюбный и заботливый нумеролог. Отвечай по-русски.";
+        $instruction = "Рассчитай и расшифруй ключевые числа нумерологии по имени {$name}, фамилии {$surname} и дате рождения {$birthDate}. " .
+            "Укажи число жизненного пути, число судьбы, число души, число личности, кармические долги и задачи, матрицу Пифагора. " .
+            "Сформируй структурированный отчёт: основные числа с кратким описанием и влиянием, текстовый прогноз 700-1500 символов по сферам (личность и потенциал, карьера и деньги, отношения и семья, сильные и слабые стороны, подсказки для настоящего периода жизни).";
+
+        return $system . "\n\n" . $instruction;
+    }
+
+    protected function buildHoroscopeFreePrompt(string $sign): string
+    {
+        return "Сгенерируй краткий дневной гороскоп (2 предложения) для знака {$sign} на сегодня. " .
+            "Стиль: мягкий, дружелюбный, например: 'Твоя энергия сейчас склонна к интроверсии, важно беречь себя. Подумай, что ты хочешь чувствовать, и начни с малого.'";
+    }
+
+    protected function buildHoroscopePrompt(string $name, string $surname, string $birthDate, string $birthTime): string
+    {
+        $system = "Ты — заботливый астролог. Отвечай по-русски.";
+        $instruction = "На основе данных: имя {$name}, фамилия {$surname}, дата рождения {$birthDate}, время рождения {$birthTime} сформируй полный гороскоп на текущий месяц. " .
+            "Включи разделы: отношения, деньги, здоровье, духовность, а также эмоциональные рекомендации. Стиль дружелюбный, поддерживающий.";
+        return $system . "\n\n" . $instruction;
+    }
+
+    protected function getZodiacSign(?string $birthDate): string
+    {
+        if (!$birthDate) return '';
+        $d = Carbon::parse($birthDate);
+        $day = (int)$d->day;
+        $month = (int)$d->month;
+
+        return match (true) {
+            ($month == 3  && $day >= 21) || ($month == 4  && $day <= 19) => 'Овен',
+            ($month == 4  && $day >= 20) || ($month == 5  && $day <= 20) => 'Телец',
+            ($month == 5  && $day >= 21) || ($month == 6  && $day <= 20) => 'Близнецы',
+            ($month == 6  && $day >= 21) || ($month == 7  && $day <= 22) => 'Рак',
+            ($month == 7  && $day >= 23) || ($month == 8  && $day <= 22) => 'Лев',
+            ($month == 8  && $day >= 23) || ($month == 9  && $day <= 22) => 'Дева',
+            ($month == 9  && $day >= 23) || ($month == 10 && $day <= 22) => 'Весы',
+            ($month == 10 && $day >= 23) || ($month == 11 && $day <= 21) => 'Скорпион',
+            ($month == 11 && $day >= 22) || ($month == 12 && $day <= 21) => 'Стрелец',
+            ($month == 12 && $day >= 22) || ($month == 1  && $day <= 19) => 'Козерог',
+            ($month == 1  && $day >= 20) || ($month == 2  && $day <= 18) => 'Водолей',
+            default => 'Рыбы',
+        };
+    }
+
     /**
      * Построение промпта для OpenAI для таро-расклада (чёткий, дружелюбный, ограничение длины).
      */
@@ -321,5 +823,88 @@ class ChatService
     protected function shorten(string $text, int $limit = 200)
     {
         return mb_strlen($text) <= $limit ? $text : mb_substr($text, 0, $limit) . '...';
+    }
+
+    protected function showSubscriptionMenu(int $chatId)
+    {
+        $text = 'Выбери тариф подписки:';
+        $keyboard = [
+            ['1 месяц', '6 месяцев (-10%)'],
+            ['12 месяцев (-10%)', 'Назад в меню'],
+        ];
+        $this->tg->sendMessage($chatId, $text, $keyboard);
+    }
+
+    protected function routeSubscriptionMenu($session, User $user, int $chatId, string $text)
+    {
+        switch ($text) {
+            case '1 месяц':
+                $user->subscription = 'paid';
+                $user->subscription_expires_at = now()->addMonth();
+                $user->save();
+                $this->tg->sendMessage($chatId, 'Подписка активирована на 1 месяц 💎');
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            case '6 месяцев (-10%)':
+                $user->subscription = 'paid';
+                $user->subscription_expires_at = now()->addMonths(6);
+                $user->save();
+                $this->tg->sendMessage($chatId, 'Подписка активирована на 6 месяцев 💎');
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            case '12 месяцев (-10%)':
+                $user->subscription = 'paid';
+                $user->subscription_expires_at = now()->addYear();
+                $user->save();
+                $this->tg->sendMessage($chatId, 'Подписка активирована на 12 месяцев 💎');
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            case 'Назад в меню':
+                $this->showMainMenu($chatId, $user);
+                $session->state = 'main_menu';
+                break;
+
+            default:
+                $this->showSubscriptionMenu($chatId);
+                $session->state = 'subscription_menu';
+                break;
+        }
+    }
+
+    protected function scheduleRetention(User $user): void
+    {
+        if (Reminder::where('chat_id', $user->chat_id)->exists()) {
+            return;
+        }
+
+        $messages = [
+            ['send_at' => now()->addHours(6), 'message' => 'Спасибо, что провела день со мной. Если ты хочешь, чтобы я была рядом всегда — подключи подписку 💌'],
+            ['send_at' => now()->addHours(12), 'message' => 'Спасибо, что провела день со мной. Если ты хочешь, чтобы я была рядом всегда — подключи подписку 💌'],
+            ['send_at' => now()->addDays(3), 'message' => 'Я всё ещё помню твой вопрос… Давай продолжим? Подписка активирует все разделы.'],
+        ];
+
+        foreach ($messages as $reminder) {
+            Reminder::create([
+                'chat_id' => $user->chat_id,
+                'message' => $reminder['message'],
+                'send_at' => $reminder['send_at'],
+            ]);
+        }
+    }
+
+    protected function askAi(string $prompt, ?string $system = null): ?string
+    {
+        try {
+            return $this->ai->getAnswer($prompt, $system);
+        } catch (\Throwable $e) {
+            Log::warning('AI error: '.$e->getMessage());
+            return null;
+        }
     }
 }

--- a/database/migrations/2025_09_03_232804_add_surname_to_users_table.php
+++ b/database/migrations/2025_09_03_232804_add_surname_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('surname')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('surname');
+        });
+    }
+};

--- a/database/migrations/2025_09_03_232805_create_numerology_readings_table.php
+++ b/database/migrations/2025_09_03_232805_create_numerology_readings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('numerology_readings', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('chat_id')->index();
+            $table->string('user_name')->nullable();
+            $table->string('surname')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('type')->default('free');
+            $table->text('result')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('numerology_readings');
+    }
+};

--- a/database/migrations/2025_09_03_232806_add_birth_time_to_users_table.php
+++ b/database/migrations/2025_09_03_232806_add_birth_time_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->time('birth_time')->nullable()->after('birth_date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('birth_time');
+        });
+    }
+};

--- a/database/migrations/2025_09_03_232807_create_horoscope_readings_table.php
+++ b/database/migrations/2025_09_03_232807_create_horoscope_readings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('horoscope_readings', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('chat_id')->index();
+            $table->string('user_name')->nullable();
+            $table->string('surname')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->time('birth_time')->nullable();
+            $table->string('sign')->nullable();
+            $table->string('type')->default('daily');
+            $table->text('result')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('horoscope_readings');
+    }
+};

--- a/database/migrations/2025_09_03_232808_add_podruzhka_used_to_users_table.php
+++ b/database/migrations/2025_09_03_232808_add_podruzhka_used_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('podruzhka_free_used_at')->nullable()->after('subscription_expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('podruzhka_free_used_at');
+        });
+    }
+};

--- a/database/migrations/2025_09_03_232809_create_reminders_table.php
+++ b/database/migrations/2025_09_03_232809_create_reminders_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reminders', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('chat_id')->index();
+            $table->text('message');
+            $table->timestamp('send_at');
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reminders');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('send:reminders')->everyFiveMinutes();


### PR DESCRIPTION
## Summary
- add subscription menu with emoji buttons and tariff selection
- enforce one free tarot, numerology, horoscope, or chat session with upsell blocks and "Получить доступ" button
- schedule retention reminders and add command to dispatch pending messages
- switch to routes-based scheduling and auto-discovered console commands for Laravel 12
- rename numerology menu helper to avoid duplicate method declaration
- fix reminder scheduling bug when creating retention tasks
- raise OpenAI API errors instead of swallowing them and wrap calls with logging to prevent Telegram retries

## Testing
- `TELEGRAM_BOT_TOKEN=dummy composer install --no-scripts`
- `TELEGRAM_BOT_TOKEN=dummy APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e0eaed08832691f7dcf62b800736